### PR TITLE
Fix authentication

### DIFF
--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -1,7 +1,9 @@
 import DS from 'ember-data';
 import config from 'lion/config/environment';
+import DataAdapterMixin from 'ember-simple-auth/mixins/data-adapter-mixin';
 
-export default DS.ActiveModelAdapter.extend({
+export default DS.ActiveModelAdapter.extend(DataAdapterMixin, {
   host: config.apiBaseUrl,
-  namespace: 'api'
+  namespace: 'api',
+  authorizer: 'authorizer:oauth2'
 });

--- a/app/authorizers/oauth2.js
+++ b/app/authorizers/oauth2.js
@@ -1,0 +1,3 @@
+import OAuth2Bearer from 'ember-simple-auth/authorizers/oauth2-bearer';
+
+export default OAuth2Bearer.extend();

--- a/app/controllers/session.js
+++ b/app/controllers/session.js
@@ -1,6 +1,13 @@
 import Ember from 'ember';
-import AuthenticationControllerMixin from 'simple-auth/mixins/authentication-controller-mixin';
 
-export default Ember.Controller.extend(AuthenticationControllerMixin, {
-  authenticator: 'authenticator:torii-oauth2'
+export default Ember.Controller.extend({
+  session: Ember.inject.service(),
+
+  actions: {
+    authenticateWithGithub(){
+      this.get('session').authenticate('authenticator:torii-oauth2', 'github-oauth2').catch((reason) => {
+        this.set('errorMessage', reason.error);
+      });
+    }
+  }
 });

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -1,4 +1,4 @@
 import Ember from 'ember';
-import ApplicationRouteMixin from 'simple-auth/mixins/application-route-mixin';
+import ApplicationRouteMixin from 'ember-simple-auth/mixins/application-route-mixin';
 
 export default Ember.Route.extend(ApplicationRouteMixin);

--- a/app/routes/authenticated.js
+++ b/app/routes/authenticated.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import AuthenticatedRouteMixin from 'simple-auth/mixins/authenticated-route-mixin';
+import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 
 export default Ember.Route.extend(AuthenticatedRouteMixin, {
   model() {

--- a/app/routes/session.js
+++ b/app/routes/session.js
@@ -1,5 +1,4 @@
 import Ember from 'ember';
-import LoginControllerMixin from 'simple-auth/mixins/login-controller-mixin';
-import UnauthenticatedRouteMixin from 'simple-auth/mixins/unauthenticated-route-mixin';
+import UnauthenticatedRouteMixin from 'ember-simple-auth/mixins/unauthenticated-route-mixin';
 
-export default Ember.Route.extend(LoginControllerMixin, UnauthenticatedRouteMixin);
+export default Ember.Route.extend(UnauthenticatedRouteMixin);

--- a/app/templates/session.hbs
+++ b/app/templates/session.hbs
@@ -1,3 +1,3 @@
-<button class="github github-login" {{action "authenticate" "github-oauth2"}}>
+<button class="github github-login" {{action "authenticateWithGithub"}}>
   Sign in with GitHub
 </button>

--- a/config/environment.js
+++ b/config/environment.js
@@ -27,12 +27,6 @@ module.exports = function(environment) {
       }
     },
 
-    'simple-auth': {
-      authenticationRoute: 'session',
-      routeAfterAuthentication: 'index',
-      authorizer: 'simple-auth-authorizer:oauth2-bearer'
-    },
-
     contentSecurityPolicy: {
       'default-src': "'none'",
       'script-src': "'self' 'unsafe-inline'",
@@ -71,11 +65,11 @@ module.exports = function(environment) {
     ENV.torii.providers['github-oauth2'].apiKey = '743d8bfa4937e587f1f4';
   }
 
-  ENV['simple-auth'].crossOriginWhitelist = [ENV.apiBaseUrl];
-
-  ENV['simple-auth-oauth2'] = {
-    serverTokenEndpoint: ENV.apiBaseUrl + '/api/tokens'
+  ENV['ember-simple-auth'] = {
+    authenticationRoute: 'session'
   };
+
+  ENV['serverTokenEndpoint'] = ENV.apiBaseUrl + '/api/tokens';
 
   return ENV;
 };


### PR DESCRIPTION
# What's up
Part of the effort in https://github.com/alphasights/lion/pull/10 was to update the authentication scheme. This new scheme relied on [Torii](http://vestorly.github.io/torii/) for its out-of-the-box github OAuth2 provider implementation, as well as [Ember Simple Auth](http://ember-simple-auth.com/) to authenticate and authorize requests to the server.

However, the latest version of Ember Simple Auth came with a lot of breaking changes. These made updating the project as a whole very difficult. Luckily, http://log.simplabs.com/post/131698328145/updating-to-ember-simple-auth-10 explains how to migrate with reduced hair-pulling.

# What this does
- Updates `ember-simple-auth` and its various usages.
- Using `ember-simple-auth`'s new conventions, gets the auth functioning properly.
- Add `DataAdapterMixin` so every request to the server for data is automatically authorized.