### PR TITLE
Stop deploying after master builds on CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,5 +1,0 @@
-deployment:
-  production:
-    branch: master
-    commands:
-      - "git push --force git@heroku.com:as-lion.git HEAD:master"


### PR DESCRIPTION
# What's up
Way back when we used to deploy using deploy hook on CI. Since the advent of heroku's Github integration, we have moved to having heroku grab the build itself.

# What this does
- Removes `circle.yml` file that instructs CircleCI to deploy to master.