### PR TITLE
Update the weekly and all-time links on the leaderboard

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -33,7 +33,7 @@
 @import 'bower_components/paint/components/grid';
 @import 'bower_components/paint/components/navigation';
 @import 'bower_components/paint/components/panel';
-
+@import 'bower_components/paint/components/tab';
 
 @import 'settings';
 @import 'default';

--- a/app/styles/components/_main-menu.scss
+++ b/app/styles/components/_main-menu.scss
@@ -27,8 +27,7 @@
     li{
       display: inline-block;
       vertical-align: middle;
-      &.weekly a        { @include icon(calendar, before) }
-      &.all-time a      { @include icon(bar-chart, before) }
+      &.chart a      { @include icon(bar-chart, before) }
       &.teams a         { @include icon(users, before) }
       &.hall-of-fame a  { @include icon(trophy, before) }
     }

--- a/app/styles/templates/_leaderboard.scss
+++ b/app/styles/templates/_leaderboard.scss
@@ -24,6 +24,15 @@ $avatar-size: 40px;
     font-size: $h1-font-size;
   }
 
+  .filters {
+    @include tabs;
+
+    text-align: center;
+    padding-bottom: $column-gutter;
+
+    .content { padding-top: $column-gutter; }
+  }
+
   h3 {
     text-align: center;
     margin-bottom: $column-gutter;

--- a/app/templates/authenticated.hbs
+++ b/app/templates/authenticated.hbs
@@ -36,8 +36,7 @@
   </svg>
   <h2 class="header">Lion</h2>
   <ul>
-    <li class="weekly">{{#link-to "leaderboard" "weekly"}}<span>Weekly</span>{{/link-to}}</li>
-    <li class="all-time">{{#link-to "leaderboard" "all-time"}}<span>All Time</span>{{/link-to}}</li>
+    <li class="chart">{{#link-to "leaderboard" "weekly"}}<span>Leaderboard</span>{{/link-to}}</li>
     <li class="teams">{{#link-to "stats"}}<span>Stats</span>{{/link-to}}</li>
     <li class="hall-of-fame">{{#link-to "hall-of-fame"}}<span>Hall of fame</span>{{/link-to}}</li>
   </ul>

--- a/app/templates/leaderboard.hbs
+++ b/app/templates/leaderboard.hbs
@@ -1,11 +1,22 @@
 <div class="leaderboard">
   <header>
     <h1>Leaderboard</h1>
-    <h3>Top 5</h3>
   </header>
-  <div class="scores">
-    {{#each arrangedScores as |score|}}
-      {{as-user-performance model=score.user points=score.points}}
-    {{/each}}
-  </div>
+  <section class="filters">
+    <nav>
+      <ul>
+        <li class="weekly">{{#link-to "leaderboard" "weekly"}}<span>Weekly</span>{{/link-to}}</li>
+        <li class="all-time">{{#link-to "leaderboard" "all-time"}}<span>All Time</span>{{/link-to}}</li>
+      </ul>
+    </nav>
+
+    <div class="content">
+      <h3>Top 5</h3>
+      <div class="scores">
+        {{#each arrangedScores as |score|}}
+          {{as-user-performance model=score.user points=score.points}}
+        {{/each}}
+      </div>
+    </div>
+  </section>
 </div>


### PR DESCRIPTION
# What's up

It's a little unclear that the 'weekly' and 'all-time' links are different flavors of the same leaderboard. They are essentially filters.

# What this does

- Moves the 'weekly' and 'all-time' links down from the main menu.
- Style them as tabs to convey their intended purpose more clearly.

### Before
![screenshot 2016-01-22 17 06 54](https://cloud.githubusercontent.com/assets/5182637/12524367/92108a82-c12a-11e5-865f-504043a8ea45.png)

### After

![](http://g.recordit.co/1cFDWjbPjd.gif)
