### PR TITLE
Add the repo scope to get access to private repos

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -22,7 +22,7 @@ module.exports = function(environment) {
     torii: {
       providers: {
         'github-oauth2': {
-          scope: 'user:email,read:org'
+          scope: 'user:email,read:org,repo'
         }
       }
     },


### PR DESCRIPTION
# What's up

According to [Github](https://developer.github.com/v3/oauth/#scopes), the _repo_ scope "grants read/write access to code, commit statuses, collaborators, and deployment statuses for public and private repositories and organizations."