### PR TITLE
Prevent setting User to Null on Empty Graph Response

### DIFF
--- a/app/score-breakdown/route.js
+++ b/app/score-breakdown/route.js
@@ -1,5 +1,6 @@
 import Route from '@ember/routing/route';
-import { set } from '@ember/object';
+import { isEmpty } from '@ember/utils';
+import { get, set } from '@ember/object';
 import RouteQueryManager from "ember-apollo-client/mixins/route-query-manager";
 import scoreBreakdownQuery from "lion/gql/queries/score-breakdowns";
 
@@ -17,9 +18,10 @@ export default Route.extend(RouteQueryManager, {
   setupController(controller, model) {
     set(controller, 'scores', model);
 
-    const users = model.mapBy('user');
-    const { user_id } = this.paramsFor('score-breakdown');
-
-    set(controller, 'user', users.findBy('id', user_id));
+    if (isEmpty(get(controller, 'user'))) {
+      const users = model.mapBy('user');
+      const { user_id } = this.paramsFor('score-breakdown');
+      set(controller, 'user', users.findBy('id', user_id));
+    }
   },
 });


### PR DESCRIPTION
### Problem
Due to how the Score Breakdown page is built, the user is set to the user content returned by the Graph request for Score data. If there is no score data for the given User+Week combination, the user will be set to null which will prevent any new requests aka changing the timespan.

### Temp Solution
For now we will only set the User when we need to initially, that way changes to the week context will not attempt to update the user with a potentially null response value.


_Future_: We will want to restructure our API to allow us to return a user regardless of if there is a score entity for a User+Week combination.


Before:
![gif](http://g.recordit.co/a8o4ZakUlc.gif)

After:
![gif](http://g.recordit.co/cLPq9azC6D.gif)
