### PR TITLE
Refactor Score Breakdown Query, Set Controller Appropriately

### DIFF
--- a/app/gql/queries/score-breakdowns.graphql
+++ b/app/gql/queries/score-breakdowns.graphql
@@ -1,22 +1,23 @@
 query scoreBreakdowns($user_id: ID!, $week: Int!) {
-  scoreBreakdowns: user(id: $user_id) {
+  user(id: $user_id) {
     id
     avatarUrl: avatar_url
     name
     nickname
-    scores: score_breakdowns(week: $week) {
+  }
+
+  scores: score_breakdowns(user_id: $user_id, week: $week) {
+    id
+    createdAt: created_at
+    points
+    review
+    pullRequest: pull_request {
       id
-      createdAt: created_at
-      points
-      review
-      pullRequest: pull_request {
-        id
-        additions
-        deletions
-        name
-        number
-        title
-      }
+      additions
+      deletions
+      name
+      number
+      title
     }
   }
 }

--- a/app/gql/queries/score-breakdowns.graphql
+++ b/app/gql/queries/score-breakdowns.graphql
@@ -1,28 +1,22 @@
 query scoreBreakdowns($user_id: ID!, $week: Int!) {
-  scoreBreakdowns: score_breakdowns(user_id: $user_id, week: $week) {
+  scoreBreakdowns: user(id: $user_id) {
     id
-    createdAt: created_at
-    points
-    review
-    pullRequest: pull_request {
+    avatarUrl: avatar_url
+    name
+    nickname
+    scores: score_breakdowns(week: $week) {
       id
-      additions
-      deletions
-      name
-      number
-      title
-      user {
+      createdAt: created_at
+      points
+      review
+      pullRequest: pull_request {
         id
-        avatarUrl: avatar_url
+        additions
+        deletions
         name
-        nickname
+        number
+        title
       }
-    }
-    user {
-      id
-      avatarUrl: avatar_url
-      name
-      nickname
     }
   }
 }

--- a/app/score-breakdown/route.js
+++ b/app/score-breakdown/route.js
@@ -1,6 +1,5 @@
 import Route from '@ember/routing/route';
-import { isEmpty } from '@ember/utils';
-import { get, set } from '@ember/object';
+import { set } from '@ember/object';
 import RouteQueryManager from "ember-apollo-client/mixins/route-query-manager";
 import scoreBreakdownQuery from "lion/gql/queries/score-breakdowns";
 
@@ -16,12 +15,9 @@ export default Route.extend(RouteQueryManager, {
   },
 
   setupController(controller, model) {
-    set(controller, 'scores', model);
+    set(controller, 'scores', model.scores);
 
-    if (isEmpty(get(controller, 'user'))) {
-      const users = model.mapBy('user');
-      const { user_id } = this.paramsFor('score-breakdown');
-      set(controller, 'user', users.findBy('id', user_id));
-    }
+    delete model.scores
+    set(controller, 'user', model);
   },
 });

--- a/app/score-breakdown/route.js
+++ b/app/score-breakdown/route.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { set } from '@ember/object';
+import { setProperties } from '@ember/object';
 import RouteQueryManager from "ember-apollo-client/mixins/route-query-manager";
 import scoreBreakdownQuery from "lion/gql/queries/score-breakdowns";
 
@@ -11,13 +11,13 @@ export default Route.extend(RouteQueryManager, {
   },
 
   model(params) {
-    return this.apollo.watchQuery({ query: scoreBreakdownQuery, variables: params }, 'scoreBreakdowns');
+    return this.apollo.watchQuery({ query: scoreBreakdownQuery, variables: params });
   },
 
   setupController(controller, model) {
-    set(controller, 'scores', model.scores);
-
-    delete model.scores
-    set(controller, 'user', model);
+    setProperties(controller, {
+      scores: model.scores,
+      user: model.user
+    });
   },
 });


### PR DESCRIPTION
### Problem
Score breakdown currently breaks when switching from one User to the other. This trend suggests that the API needs to be restructured to support this.

### Solution
With the Graphql Types restructured, we can now resolve score breakdowns off of a User query which ensures that our response will always have the relevant user model. The controller setup is refactored to account for the different response structure.