### PR TITLE
Introduce the Initial Feed View.

### DIFF
--- a/app/authenticated/template.hbs
+++ b/app/authenticated/template.hbs
@@ -36,6 +36,7 @@
   </svg>
   <h2 class="header">Lion</h2>
   <ul>
+    <li class="live-feed">{{#link-to "feed"}}<span>Feed</span>{{/link-to}}</li>
     <li class="chart">{{#link-to "leaderboard" "weekly"}}<span>Leaderboard</span>{{/link-to}}</li>
     <li class="teams">{{#link-to "stats" "pull_requests"}}<span>Stats</span>{{/link-to}}</li>
     <li class="trophy">{{#link-to "hall-of-fame"}}<span>Hall of fame</span>{{/link-to}}</li>

--- a/app/components/pull-request/component.js
+++ b/app/components/pull-request/component.js
@@ -1,0 +1,29 @@
+import Component from '@ember/component';
+import { computed, get } from '@ember/object';
+import { alias } from '@ember/object/computed';
+import { inject as service } from '@ember/service';
+
+export default Component.extend({
+  classNames: ['pull-request'],
+
+  router: service(),
+
+  pullRequest: null,
+
+  additions: alias('pullRequest.additions'),
+  deletions: alias('pullRequest.deletions'),
+  number: alias('pullRequest.number'),
+  points: alias('pullRequest.score.points'),
+  title: alias('pullRequest.title'),
+  user: alias('pullRequest.user'),
+
+  breakdownUrl: computed('user.id', function() {
+    return get(this, 'router').urlFor('score-breakdown', get(this, 'user.id'));
+  }),
+  repo: computed('pullRequest.name', function() {
+    const fullName = get(this, 'pullRequest.name');
+    const match = fullName.match('[a-z]+$');
+
+    return match.pop();
+  }),
+});

--- a/app/components/pull-request/template.hbs
+++ b/app/components/pull-request/template.hbs
@@ -1,0 +1,19 @@
+<div class="avatar">{{user-avatar user=user}}</div>
+<div class="info">
+  <div class="summary">
+    <span class="nickname">{{user.nickname}}</span> merged <a href={{concat 'https://github.com/' repo '/pull/' number}} target="_blank" class="title">{{title}}</a>.
+  </div>
+  <div class="details">
+    <span class="details--{{repo}}">{{repo}}</span>|
+    <span>{{moment-format pullRequest.createdAt "hh:mm a MMM Do YYYY"}}</span>
+  </div>
+</div>
+
+<div class="statistics">
+  <div class="number number--points">{{points}}</div>
+  <div class="number">
+    <span class="number--additions">+ {{additions}}</span>
+    /
+    <span class="number--deletions">- {{deletions}}</span>
+  </div>
+</div>

--- a/app/feed/route.js
+++ b/app/feed/route.js
@@ -1,0 +1,10 @@
+import Route from '@ember/routing/route';
+import { set } from '@ember/object';
+import RouteQueryManager from "ember-apollo-client/mixins/route-query-manager";
+import query from "lion/gql/queries/recent-pull-requests";
+
+export default Route.extend(RouteQueryManager, {
+  model() {
+    return this.apollo.watchQuery({ query }, 'pullRequests');
+  }
+});

--- a/app/feed/route.js
+++ b/app/feed/route.js
@@ -1,5 +1,4 @@
 import Route from '@ember/routing/route';
-import { set } from '@ember/object';
 import RouteQueryManager from "ember-apollo-client/mixins/route-query-manager";
 import query from "lion/gql/queries/recent-pull-requests";
 

--- a/app/feed/template.hbs
+++ b/app/feed/template.hbs
@@ -1,0 +1,13 @@
+{{outlet}}
+<div class="feed">
+  <header>
+    <h1>Recent Pull Requests</h1>
+  </header>
+  <section class="content">
+    <div class="pull-requests">
+      {{#each model as |pr|}}
+        {{pull-request pullRequest=pr}}
+      {{/each}}
+    </div>
+  </section>
+</div>

--- a/app/gql/queries/recent-pull-requests.graphql
+++ b/app/gql/queries/recent-pull-requests.graphql
@@ -1,0 +1,20 @@
+query recentPullRequests($limit: Int) {
+  pullRequests: recent_pull_requests(limit: $limit) {
+    id
+    additions
+    createdAt: created_at
+    deletions
+    name
+    number
+    title
+    user {
+      id
+      avatarUrl: avatar_url
+      name
+      nickname
+    }
+    score {
+      points
+    }
+  }
+}

--- a/app/router.js
+++ b/app/router.js
@@ -8,6 +8,7 @@ const Router = EmberRouter.extend({
 
 Router.map(function() {
   this.route('authenticated', { path: '/', resetNamespace: true }, function() {
+    this.route('feed', { resetNamespace: true });
     this.route('hall-of-fame', { resetNamespace: true });
     this.route('leaderboard', { path: 'leaderboard/:time_span', resetNamespace: true });
     this.route('score-breakdown', { path: 'score-breakdown/:user_id', resetNamespace: true });

--- a/app/styles/_paint-settings.scss
+++ b/app/styles/_paint-settings.scss
@@ -1,4 +1,5 @@
 $layout-sidebar-nav-classes:
+  feed,
   leaderboard,
   hall-of-fame,
   stats;

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -39,8 +39,10 @@
 @import 'default';
 
 @import 'components/main-menu';
+@import 'components/pull-request';
 @import 'components/user-performance';
 @import 'templates/session';
+@import 'templates/feed';
 @import 'templates/leaderboard';
 @import 'templates/hall-of-fame';
 @import 'templates/score-breakdown';

--- a/app/styles/components/_main-menu.scss
+++ b/app/styles/components/_main-menu.scss
@@ -27,6 +27,7 @@
     li{
       display: inline-block;
       vertical-align: middle;
+      &.live-feed a   { @include icon(github, before) }
       &.chart a   { @include icon(bar-chart, before) }
       &.teams a   { @include icon(users, before) }
       &.trophy a  { @include icon(trophy, before) }

--- a/app/styles/components/_pull-request.scss
+++ b/app/styles/components/_pull-request.scss
@@ -1,0 +1,54 @@
+.pull-request {
+  padding: $column-gutter / 2 $column-gutter;
+  transition: background-color $global-transition-duration ease;
+
+  &:nth-child(2n) {
+    background-color: color(gray, ghost);
+  }
+
+  &:hover {
+    background-color: #d9f2ff;
+  }
+
+  .avatar {
+    background-color: color(gray, smoke);
+    width: 3em;
+    border-radius: 50%;
+    height: 3em;
+    text-align: center;
+    overflow: hidden;
+    display: block;
+  }
+
+  .info {
+    padding-left: 1rem;
+    flex-grow: 2;
+
+    .summary {
+      align-content: flex-end;
+
+      .nickname {
+        font-weight: 400;
+      }
+    }
+    .details {
+      color: darkgray;
+
+      &--pistachio { color: #93B19A; }
+      &--phoenix { color: #b19993; }
+    }
+  }
+
+  .statistics {
+    flex-direction: column;
+
+    .number {
+      color: darkgray;
+      font-weight: 400;
+
+      &--additions { color: #3D9970; }
+      &--deletions { color: #FF4136; }
+      &--points { text-align: right; color: #0074D9; }
+    }
+  }
+}

--- a/app/styles/templates/_feed.scss
+++ b/app/styles/templates/_feed.scss
@@ -1,0 +1,42 @@
+$wrapper-max-width: 800px;
+$avatar-size: 40px;
+
+.feed {
+  padding: $column-gutter;
+  position: absolute;
+  top: $layout-sidebar-header-height;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+
+  @media #{$small-only} {
+    padding: $column-gutter / 2;
+
+    .nickname {
+      font-size: $h5-font-size;
+    }
+  }
+
+  h1 {
+    text-align: center;
+    font-size: $h1-font-size;
+  }
+
+  h3 {
+    text-align: center;
+    margin-bottom: $column-gutter;
+  }
+
+  .pull-requests {
+    max-width: $wrapper-max-width;
+    margin: 0 auto;
+
+    .pull-request {
+      color: black;
+      display: flex;
+      flex-direction: row;
+    }
+  }
+}

--- a/app/styles/templates/_score-breakdown.scss
+++ b/app/styles/templates/_score-breakdown.scss
@@ -6,29 +6,28 @@
   max-width: 80rem;
   padding: 1rem;
 }
-
 .github-handle {
   @include icon(github, before);
 }
 
 .pull-request-list {
   padding-top: 1rem;
-}
 
-.pull-request {
-  color: #9E9E9E;
-  flex-direction: row;
+  .pull-request {
+    color: #9E9E9E;
+    flex-direction: row;
 
-  &__title {
-    color: black;
-    font-weight: 400;
-  }
+    &__title {
+      color: black;
+      font-weight: 400;
+    }
 
-  &__number {
-    font-weight: 400;
+    &__number {
+      font-weight: 400;
 
-    &--additions { color: #3D9970; }
-    &--deletions { color: #FF4136; }
-    &--points { color: #0074D9; }
+      &--additions { color: #3D9970; }
+      &--deletions { color: #FF4136; }
+      &--points { color: #0074D9; }
+    }
   }
 }

--- a/tests/integration/components/pull-request/component-test.js
+++ b/tests/integration/components/pull-request/component-test.js
@@ -1,3 +1,4 @@
+import { set } from '@ember/object';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
@@ -6,19 +7,26 @@ moduleForComponent('pull-request', 'Integration | Component | pull request', {
 });
 
 test('it renders', function(assert) {
-  // Set any properties with this.set('myProperty', 'value');
-  // Handle any actions with this.on('myAction', function(val) { ... });
+  assert.expect(4);
+  const user = {
+    avatarUrl: 'http://placeholder.it/350x350',
+    nickname: 'John Smith'
+  };
+  const score = { points: 50 };
+  const pullRequest = {
+    additions: 200,
+    deletions: 300,
+    name: 'Lion',
+    number: 12,
+    title: 'Added PR Feed',
+    score: score,
+    user: user
+  };
+  set(this, 'pullRequest', pullRequest);
+  this.render(hbs`{{pull-request pullRequest=pullRequest}}`);
 
-  this.render(hbs`{{pull-request}}`);
-
-  assert.equal(this.$().text().trim(), '');
-
-  // Template block usage:
-  this.render(hbs`
-    {{#pull-request}}
-      template block text
-    {{/pull-request}}
-  `);
-
-  assert.equal(this.$().text().trim(), 'template block text');
+  assert.equal(this.$('.summary').text().trim(), 'John Smith merged Added PR Feed.');
+  assert.equal(this.$('.number--points').text().trim(), '50');
+  assert.equal(this.$('.number--additions').text().trim(), '+ 200');
+  assert.equal(this.$('.number--deletions').text().trim(), '- 300');
 });

--- a/tests/integration/components/pull-request/component-test.js
+++ b/tests/integration/components/pull-request/component-test.js
@@ -1,0 +1,24 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('pull-request', 'Integration | Component | pull request', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.render(hbs`{{pull-request}}`);
+
+  assert.equal(this.$().text().trim(), '');
+
+  // Template block usage:
+  this.render(hbs`
+    {{#pull-request}}
+      template block text
+    {{/pull-request}}
+  `);
+
+  assert.equal(this.$().text().trim(), 'template block text');
+});

--- a/tests/unit/feed/route-test.js
+++ b/tests/unit/feed/route-test.js
@@ -1,0 +1,11 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('route:feed', 'Unit | Route | feed', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+test('it exists', function(assert) {
+  let route = this.subject();
+  assert.ok(route);
+});

--- a/tests/unit/feed/route-test.js
+++ b/tests/unit/feed/route-test.js
@@ -1,8 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('route:feed', 'Unit | Route | feed', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:apollo', 'service:session']
 });
 
 test('it exists', function(assert) {


### PR DESCRIPTION
### What's New
Introducing the new 'Feed' view to Lion which gives a single location for users to see all recent Pull Requests merged in organization repos. This is the initial version of this view with future plans of pagination, better UI/UX and more importantly, WebSocket implementation to provide a 'Live' Feed in the near future.

### Main Changes
- Add Feed Route
- Add Pull Request Component for viewing PR's on feed view
- Add recent pull request graphql query

<img width="1429" alt="screen shot 2018-03-11 at 10 36 35 pm" src="https://user-images.githubusercontent.com/9739680/37263414-750cf262-257e-11e8-93d1-9a563a2f1db7.png">


